### PR TITLE
Add blinker to resolve crashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ alembic==0.9.9
 asn1crypto==0.24.0
 astroid==1.6.2
 Beaker==1.9.0
+blinker==1.4
 certifi==2018.1.18
 cffi==1.14.0
 chardet==3.0.4
@@ -25,7 +26,7 @@ Mako==1.0.7
 MarkupSafe==1.0
 mccabe==0.6.1
 oic==0.11.0.1
-Pillow==6.2.0
+Pillow==6.2.2
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
 pycparser==2.18
@@ -45,5 +46,5 @@ six==1.11.0
 sentry-sdk==0.14.3
 SQLAlchemy~=1.3.0
 urllib3==1.24.2
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 wrapt==1.10.11


### PR DESCRIPTION
selections-dev container is in a crash loop with the error RuntimeError: signalling support is unavailable because the blinker library is not installed.
